### PR TITLE
Close hid device when exiting to prevent error

### DIFF
--- a/relay.py
+++ b/relay.py
@@ -1,4 +1,5 @@
 import hid
+import atexit
 
 """
 
@@ -26,6 +27,10 @@ class Relay(object):
 		self.h = hid.device()
 		self.h.open(idVendor, idProduct)
 		self.h.set_nonblocking(1)
+		atexit.register(self.cleanup)
+
+	def cleanup(self):
+		self.h.close()
 
 	def get_switch_statuses_from_report(self, report):
 		"""


### PR DESCRIPTION
I was finding that every time I ran the relay script, I got this error at the end of the program:

```
python3: ../../libusb/io.c:2116: handle_events: Assertion `ctx->pollfds_cnt >= internal_nfds' failed.
Aborted
```

This pull request fixes that by adding a cleanup function to close the hid device when quitting.